### PR TITLE
feat: add flash mode in keyboard select patch

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -390,7 +390,7 @@ static Shortcut shortcuts[] = {
 	{ TERMMOD,              XK_space,       keyboard_select, { 0 } },
 	{ TERMMOD,              XK_F,           searchforward,   { 0 } },
 	{ TERMMOD,              XK_B,           searchbackward,  { 0 } },
-	{ TERMMOD,              XK_i,           keyboard_flash,  { 0 } },
+	{ TERMMOD,              XK_I,           keyboard_flash,  { 0 } },
 	{ TERMMOD,              XK_Z,           scrolltoprompt,  {.i = -1}, S_PRI },
 	{ TERMMOD,              XK_X,           scrolltoprompt,  {.i =  1}, S_PRI },
 	{ XK_NO_MOD,            XK_F11,         fullscreen,      {.i =  0} },

--- a/config.def.h
+++ b/config.def.h
@@ -251,7 +251,7 @@ unsigned int highlightbg = 160;
 
 /* Foreground and background color of flash label */
 unsigned int flashlabelfg = 15;
-unsigned int flashlabelbg = 9;
+unsigned int flashlabelbg = 4;
 unsigned int flashtextfg = 8;
 unsigned int flashtextbg = 0;
 

--- a/config.def.h
+++ b/config.def.h
@@ -390,7 +390,7 @@ static Shortcut shortcuts[] = {
 	{ TERMMOD,              XK_space,       keyboard_select, { 0 } },
 	{ TERMMOD,              XK_F,           searchforward,   { 0 } },
 	{ TERMMOD,              XK_B,           searchbackward,  { 0 } },
-	{ ControlMask,          XK_i,           keyboard_flash,  { 0 } },
+	{ TERMMOD,              XK_i,           keyboard_flash,  { 0 } },
 	{ TERMMOD,              XK_Z,           scrolltoprompt,  {.i = -1}, S_PRI },
 	{ TERMMOD,              XK_X,           scrolltoprompt,  {.i =  1}, S_PRI },
 	{ XK_NO_MOD,            XK_F11,         fullscreen,      {.i =  0} },

--- a/config.def.h
+++ b/config.def.h
@@ -249,6 +249,12 @@ unsigned int visualbellcolor = 261;
 unsigned int highlightfg = 15;
 unsigned int highlightbg = 160;
 
+/* Foreground and background color of flash label */
+unsigned int flashlabelfg = 15;
+unsigned int flashlabelbg = 9;
+unsigned int flashtextfg = 8;
+unsigned int flashtextbg = 0;
+
 /* Foreground and background color of the hyperlink hint */
 unsigned int hyperlinkhintfg = 0;
 unsigned int hyperlinkhintbg = 258;
@@ -384,6 +390,7 @@ static Shortcut shortcuts[] = {
 	{ TERMMOD,              XK_space,       keyboard_select, { 0 } },
 	{ TERMMOD,              XK_F,           searchforward,   { 0 } },
 	{ TERMMOD,              XK_B,           searchbackward,  { 0 } },
+	{ ControlMask,          XK_i,           keyboard_flash,  { 0 } },
 	{ TERMMOD,              XK_Z,           scrolltoprompt,  {.i = -1}, S_PRI },
 	{ TERMMOD,              XK_X,           scrolltoprompt,  {.i =  1}, S_PRI },
 	{ XK_NO_MOD,            XK_F11,         fullscreen,      {.i =  0} },
@@ -726,6 +733,10 @@ ResourcePref resources[] = {
 		{ "visualbellcolor",     STRING,  &colorname[261] },
 		{ "highlightfg",         INTEGER, &highlightfg },
 		{ "highlightbg",         INTEGER, &highlightbg },
+		{ "flashlabelfg",        INTEGER, &flashlabelfg },
+		{ "flashlabelbg",        INTEGER, &flashlabelbg },
+		{ "flashtextfg",         INTEGER, &flashtextfg },
+		{ "flashtextbg",         INTEGER, &flashtextbg },
 		{ "hyperlinkhintfg",     INTEGER, &hyperlinkhintfg },
 		{ "hyperlinkhintbg",     INTEGER, &hyperlinkhintbg },
 		{ "kbselectfg",          INTEGER, &kbselectfg },

--- a/keyboardselect.txt
+++ b/keyboardselect.txt
@@ -24,7 +24,8 @@ t, T:                    jump forward/backward to before the given character
 , or R                   repeat previous f, t, F or T movement and move backward
 v:                       toggle selection mode
 V:                       toggle line selection mode
-s:                       toggle regular/rectangular selection type
+S:                       toggle regular/rectangular selection type
+s:                       jump to flash mode
 y:                       yank (copy) selected text
 Z, X:                    jump to previous/next shell prompt that contains the OSC "133;A" sequence
 u:                       open hyperlink under the cursor

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -644,7 +644,7 @@ kbds_searchall(void)
 	int begin = kbds_isflashmode() ? 0 : kbds_top();
 	int end = kbds_isflashmode() ? term.row - 1 : kbds_bot();
 
-	for (c.y = kbds_top(); c.y <= kbds_bot(); c.y++) {
+	for (c.y = begin; c.y <= end; c.y++) {
 		c.line = TLINE(c.y);
 		c.len = tlinelen(c.line);
 		for (c.x = 0; c.x < c.len; c.x++)

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -667,7 +667,7 @@ kbds_searchall(void)
 			count += kbds_ismatch(c);
 	}
 
-    for ( i = 0; i < 52; i++) {
+	for (i = 0; i < LEN(flash_key_label); i++) {
 		is_invalid_label = 0;
 		for ( j = 0; j < flash_next_char_record.used; j++) {
 			if (flash_next_char_record.array[j] == *flash_key_label[i]) {

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -34,7 +34,7 @@ struct {
 } kbds_searchobj;
 
 typedef struct {
-    char *array;
+    Rune *array;
     size_t used;
     size_t size;
 } CharArray;
@@ -65,16 +65,16 @@ static const char *flash_key_label[52] = {
 
 void
 init_char_array(CharArray *a, size_t initialSize) {
-    a->array = (char *)xmalloc(initialSize * sizeof(char));
+    a->array = (Rune *)xmalloc(initialSize * sizeof(Rune));
     a->used = 0;
     a->size = initialSize;
 }
 
 void
-insert_char_array(CharArray *a, char element) {
+insert_char_array(CharArray *a, Rune element) {
     if (a->used == a->size) {
         a->size *= 2;
-        a->array = (char *)xrealloc(a->array, a->size * sizeof(char));
+        a->array = (Rune *)xrealloc(a->array, a->size * sizeof(Rune));
     }
     a->array[a->used++] = element;
 }
@@ -113,109 +113,9 @@ reset_kcursor_array(KCursorArray *a) {
     a->size = 0;
 }
 
-char
-keysym_to_char(unsigned int keysym) {
-    switch (keysym) {
-        case XK_0: return '0';
-        case XK_1: return '1';
-        case XK_2: return '2';
-        case XK_3: return '3';
-        case XK_4: return '4';
-        case XK_5: return '5';
-        case XK_6: return '6';
-        case XK_7: return '7';
-        case XK_8: return '8';
-        case XK_9: return '9';
-        case XK_KP_0: return '0';
-        case XK_KP_1: return '1';
-        case XK_KP_2: return '2';
-        case XK_KP_3: return '3';
-        case XK_KP_4: return '4';
-        case XK_KP_5: return '5';
-        case XK_KP_6: return '6';
-        case XK_KP_7: return '7';
-        case XK_KP_8: return '8';
-        case XK_KP_9: return '9';
-        case XK_exclam: return '!';
-        case XK_at: return '@';
-        case XK_numbersign: return '#';
-        case XK_dollar: return '$';
-        case XK_percent: return '%';
-        case XK_asciicircum: return '^';
-        case XK_ampersand: return '&';
-        case XK_asterisk: return '*';
-        case XK_parenleft: return '(';
-        case XK_parenright: return ')';
-        case XK_minus: return '-';
-        case XK_underscore: return '_';
-        case XK_equal: return '=';
-        case XK_plus: return '+';
-		case XK_period : return '.';
-        case XK_BackSpace: return '\b';
-        case XK_Tab: return '\t';
-        case XK_Linefeed: return '\n';
-        case XK_Return: return '\r';
-        case XK_space: return ' ';
-        case XK_a: return 'a';
-        case XK_b: return 'b';
-        case XK_c: return 'c';
-        case XK_d: return 'd';
-        case XK_e: return 'e';
-        case XK_f: return 'f';
-        case XK_g: return 'g';
-        case XK_h: return 'h';
-        case XK_i: return 'i';
-        case XK_j: return 'j';
-        case XK_k: return 'k';
-        case XK_l: return 'l';
-        case XK_m: return 'm';
-        case XK_n: return 'n';
-        case XK_o: return 'o';
-        case XK_p: return 'p';
-        case XK_q: return 'q';
-        case XK_r: return 'r';
-        case XK_s: return 's';
-        case XK_t: return 't';
-        case XK_u: return 'u';
-        case XK_v: return 'v';
-        case XK_w: return 'w';
-        case XK_x: return 'x';
-        case XK_y: return 'y';
-        case XK_z: return 'z';
-        case XK_A: return 'A';
-        case XK_B: return 'B';
-        case XK_C: return 'C';
-        case XK_D: return 'D';
-        case XK_E: return 'E';
-        case XK_F: return 'F';
-        case XK_G: return 'G';
-        case XK_H: return 'H';
-        case XK_I: return 'I';
-        case XK_J: return 'J';
-        case XK_K: return 'K';
-        case XK_L: return 'L';
-        case XK_M: return 'M';
-        case XK_N: return 'N';
-        case XK_O: return 'O';
-        case XK_P: return 'P';
-        case XK_Q: return 'Q';
-        case XK_R: return 'R';
-        case XK_S: return 'S';
-        case XK_T: return 'T';
-        case XK_U: return 'U';
-        case XK_V: return 'V';
-        case XK_W: return 'W';
-        case XK_X: return 'X';
-        case XK_Y: return 'Y';
-        case XK_Z: return 'Z';
-        default: return '?'; // Unknown keysym
-    }
-}
-
 int
-is_in_flash_used_label(unsigned int keysym) {
+is_in_flash_used_label(Rune label) {
 	int i;
-	char label = keysym_to_char(keysym);
 	for ( i = 0; i < flash_used_label.used; i++) {
 		if (label == flash_used_label.array[i]) {
 			return 1;
@@ -225,9 +125,8 @@ is_in_flash_used_label(unsigned int keysym) {
 }
 
 int
-is_in_flash_next_char_record(unsigned int keysym) {
+is_in_flash_next_char_record(Rune label) {
 	int i;
-	char label = keysym_to_char(keysym);
 	for ( i = 0; i < flash_next_char_record.used; i++) {
 		if (label == flash_next_char_record.array[i]) {
 			return 1;
@@ -590,6 +489,7 @@ kbds_ismatch(KCursor c)
 {
 	KCursor m = c;
 	int i, next;
+	Rune u;
 
 	if (c.x + kbds_searchobj.len > c.len && (!kbds_iswrapped(&c) || c.y >= kbds_bot()))
 		return 0;
@@ -618,7 +518,8 @@ kbds_ismatch(KCursor c)
 
 	if (kbds_isflashmode()) {
 		m.line[m.x].ubk = m.line[m.x].u;
-		insert_char_array(&flash_next_char_record, m.line[m.x].u);
+		u = kbds_searchobj.ignorecase ? towlower(m.line[m.x].u) : m.line[m.x].u;
+		insert_char_array(&flash_next_char_record, u);
 		insert_kcursor_array(&flash_kcursor_record, m);
 	}
 
@@ -680,9 +581,8 @@ kbds_searchall(void)
 }
 
 void
-jump_to_label(unsigned int keysym, int len) {
+jump_to_label(Rune label, int len) {
 	int i;
-	char label = keysym_to_char(keysym);
 	for ( i = 0; i < flash_kcursor_record.used; i++) {
 		if (label == flash_kcursor_record.array[i].line[flash_kcursor_record.array[i].x].u) {
 			kbds_moveto(flash_kcursor_record.array[i].x-len, flash_kcursor_record.array[i].y);
@@ -911,21 +811,21 @@ kbds_keyboardhandler(KeySym ksym, char *buf, int len, int forcequit)
 			return 0;
 		default:
 			if (len > 0) {
-				if (is_in_flash_used_label(ksym) == 1) {
-					jump_to_label(ksym,kbds_searchobj.len);
+				utf8decode(buf, &u, len);
+				if (is_in_flash_used_label(u) == 1) {
+					jump_to_label(u, kbds_searchobj.len);
 					kbds_searchobj.len = 0;
 					kbds_setmode(kbds_mode & ~KBDS_MODE_FLASH);
 					clear_flash_cache();
 					kbds_clearhighlights();
 					kbds_selecttext();
 					return 0;
-				} else if(ksym,kbds_searchobj.len > 0 && is_in_flash_next_char_record(ksym) == 0) {
+				} else if (kbds_searchobj.len > 0 && is_in_flash_next_char_record(u) == 0) {
 					return 0;
 				} else {
 					clear_flash_cache();
 				}
 				kbds_clearhighlights();
-				utf8decode(buf, &u, len);
 				kbds_insertchar(u);
 				for (kbds_searchobj.ignorecase = 1, i = 0; i < kbds_searchobj.len; i++) {
 					if (kbds_searchobj.str[i].u != towlower(kbds_searchobj.str[i].u)) {

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -678,7 +678,7 @@ kbds_searchall(void)
 		if (is_invalid_label == 0) {
 			insert_char_array(&valid_label, *flash_key_label[i]);
 		}
-    }
+	}
 
 	for ( i = 0; i < flash_kcursor_record.used; i++) {
 		if (i < valid_label.used) {

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -915,7 +915,6 @@ kbds_keyboardhandler(KeySym ksym, char *buf, int len, int forcequit)
 					clear_flash_cache();
 					kbds_clearhighlights();
 					return 0;
-					break;
 				} else if(ksym,kbds_searchobj.len > 0 && is_in_flash_next_char_record(ksym) == 0) {
 					return 0;
 				} else {

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -889,8 +889,6 @@ kbds_keyboardhandler(KeySym ksym, char *buf, int len, int forcequit)
 		case XK_BackSpace:
 			if (kbds_searchobj.cx == 0)
 				break;
-		case XK_Left:
-		case XK_KP_Left:
 			kbds_clearhighlights();
 			kbds_searchobj.cx = MAX(kbds_searchobj.cx-1, 0);
 			if (kbds_searchobj.str[kbds_searchobj.cx].mode & ATTR_WDUMMY)

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -914,6 +914,7 @@ kbds_keyboardhandler(KeySym ksym, char *buf, int len, int forcequit)
 					kbds_setmode(kbds_mode & ~KBDS_MODE_FLASH);
 					clear_flash_cache();
 					kbds_clearhighlights();
+					kbds_selecttext();
 					return 0;
 				} else if(ksym,kbds_searchobj.len > 0 && is_in_flash_next_char_record(ksym) == 0) {
 					return 0;

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -34,15 +34,15 @@ struct {
 } kbds_searchobj;
 
 typedef struct {
-    Rune *array;
-    size_t used;
-    size_t size;
+	Rune *array;
+	size_t used;
+	size_t size;
 } CharArray;
 
 typedef struct {
-    KCursor *array;
-    size_t used;
-    size_t size;   
+	KCursor *array;
+	size_t used;
+	size_t size;
 } KCursorArray;
 
 static int kbds_in_use, kbds_quant;
@@ -55,62 +55,62 @@ static CharArray flash_next_char_record, flash_used_label;
 static KCursorArray flash_kcursor_record;
 
 static const char *flash_key_label[52] = {
-	"j", "f", "d", "k", "l", "h", "g", "a", "s", "o", 
-	"i", "e", "u", "n", "c", "m", "r", "p", "b", "t", 
+	"j", "f", "d", "k", "l", "h", "g", "a", "s", "o",
+	"i", "e", "u", "n", "c", "m", "r", "p", "b", "t",
 	"w", "v", "x", "y", "q", "z",
-	"I", "J", "L", "H", "A", "B", "Y", "D", "E", "F", 
+	"I", "J", "L", "H", "A", "B", "Y", "D", "E", "F",
 	"G", "Q", "R", "T", "U", "V", "W", "X", "Z", "C",
 	"K", "M", "N", "O", "P", "S"
 };
 
 void
 init_char_array(CharArray *a, size_t initialSize) {
-    a->array = (Rune *)xmalloc(initialSize * sizeof(Rune));
-    a->used = 0;
-    a->size = initialSize;
+	a->array = (Rune *)xmalloc(initialSize * sizeof(Rune));
+	a->used = 0;
+	a->size = initialSize;
 }
 
 void
 insert_char_array(CharArray *a, Rune element) {
-    if (a->used == a->size) {
-        a->size *= 2;
-        a->array = (Rune *)xrealloc(a->array, a->size * sizeof(Rune));
-    }
-    a->array[a->used++] = element;
+	if (a->used == a->size) {
+		a->size *= 2;
+		a->array = (Rune *)xrealloc(a->array, a->size * sizeof(Rune));
+	}
+	a->array[a->used++] = element;
 }
 
 void
 reset_char_array(CharArray *a) {
-    free(a->array);
-    a->array = NULL;
-    a->used = 0;
-    a->size = 0;
+	free(a->array);
+	a->array = NULL;
+	a->used = 0;
+	a->size = 0;
 }
 
 void
 init_kcursor_array(KCursorArray *a, size_t initialSize) {
-    a->array = (KCursor *)xmalloc(initialSize * sizeof(KCursor));
-    a->used = 0;
-    a->size = initialSize;
+	a->array = (KCursor *)xmalloc(initialSize * sizeof(KCursor));
+	a->used = 0;
+	a->size = initialSize;
 }
 
 void
 insert_kcursor_array(KCursorArray *a, KCursor element) {
-    if (a->used == a->size) {
-        size_t newSize = a->size == 0 ? 1 : a->size * 2;
-        KCursor *newArray = (KCursor *)xrealloc(a->array, newSize * sizeof(KCursor));
-        a->array = newArray;
-        a->size = newSize;
-    }
-    a->array[a->used++] = element;
+	if (a->used == a->size) {
+		size_t newSize = a->size == 0 ? 1 : a->size * 2;
+		KCursor *newArray = (KCursor *)xrealloc(a->array, newSize * sizeof(KCursor));
+		a->array = newArray;
+		a->size = newSize;
+	}
+	a->array[a->used++] = element;
 }
 
 void
 reset_kcursor_array(KCursorArray *a) {
-    free(a->array);
-    a->array = NULL;
-    a->used = 0;
-    a->size = 0;
+	free(a->array);
+	a->array = NULL;
+	a->used = 0;
+	a->size = 0;
 }
 
 int
@@ -835,7 +835,7 @@ kbds_keyboardhandler(KeySym ksym, char *buf, int len, int forcequit)
 				}
 				kbds_searchobj.wordonly = 0;
 				count = kbds_searchall();
-				return 0;				
+				return 0;
 			}
 			break;
 		}
@@ -1081,7 +1081,7 @@ kbds_keyboardhandler(KeySym ksym, char *buf, int len, int forcequit)
 		break;
 	case XK_M:
 		kbds_moveto(kbds_c.x, alt ? (term.row-1) / 2
-                                  : MIN(term.c.y + term.scr, term.row-1) / 2);
+		                          : MIN(term.c.y + term.scr, term.row-1) / 2);
 		break;
 	case XK_L:
 		kbds_moveto(kbds_c.x, alt ? term.row-1

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -66,10 +66,6 @@ static const char *flash_key_label[52] = {
 void
 init_char_array(CharArray *a, size_t initialSize) {
     a->array = (char *)xmalloc(initialSize * sizeof(char));
-    if (!a->array) {
-        perror("Failed to allocate memory");
-        exit(EXIT_FAILURE);
-    }
     a->used = 0;
     a->size = initialSize;
 }
@@ -94,10 +90,6 @@ reset_char_array(CharArray *a) {
 void
 init_kcursor_array(KCursorArray *a, size_t initialSize) {
     a->array = (KCursor *)xmalloc(initialSize * sizeof(KCursor));
-    if (!a->array) {
-        perror("Failed to allocate memory");
-        exit(EXIT_FAILURE);
-    }
     a->used = 0;
     a->size = initialSize;
 }

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -65,7 +65,7 @@ static const char *flash_key_label[52] = {
 
 void
 init_char_array(CharArray *a, size_t initialSize) {
-    a->array = (char *)malloc(initialSize * sizeof(char));
+    a->array = (char *)xmalloc(initialSize * sizeof(char));
     if (!a->array) {
         perror("Failed to allocate memory");
         exit(EXIT_FAILURE);
@@ -78,11 +78,7 @@ void
 insert_char_array(CharArray *a, char element) {
     if (a->used == a->size) {
         a->size *= 2;
-        a->array = (char *)realloc(a->array, a->size * sizeof(char));
-        if (!a->array) {
-            perror("Failed to reallocate memory");
-            exit(EXIT_FAILURE);
-        }
+        a->array = (char *)xrealloc(a->array, a->size * sizeof(char));
     }
     a->array[a->used++] = element;
 }
@@ -97,7 +93,7 @@ reset_char_array(CharArray *a) {
 
 void
 init_kcursor_array(KCursorArray *a, size_t initialSize) {
-    a->array = (KCursor *)malloc(initialSize * sizeof(KCursor));
+    a->array = (KCursor *)xmalloc(initialSize * sizeof(KCursor));
     if (!a->array) {
         perror("Failed to allocate memory");
         exit(EXIT_FAILURE);
@@ -110,11 +106,7 @@ void
 insert_kcursor_array(KCursorArray *a, KCursor element) {
     if (a->used == a->size) {
         size_t newSize = a->size == 0 ? 1 : a->size * 2;
-        KCursor *newArray = (KCursor *)realloc(a->array, newSize * sizeof(KCursor));
-        if (!newArray) {
-            perror("Failed to reallocate memory");
-            exit(EXIT_FAILURE);
-        }
+        KCursor *newArray = (KCursor *)xrealloc(a->array, newSize * sizeof(KCursor));
         a->array = newArray;
         a->size = newSize;
     }

--- a/patch/keyboardselect_st.c
+++ b/patch/keyboardselect_st.c
@@ -885,7 +885,12 @@ kbds_keyboardhandler(KeySym ksym, char *buf, int len, int forcequit)
 			kbds_searchobj.len = 0;
 			kbds_setmode(kbds_mode & ~KBDS_MODE_FLASH);
 			clear_flash_cache();
-			break;
+			kbds_clearhighlights();
+			/* If the direct search is aborted, we just go to the next switch
+			 * statement and exit the keyboard selection mode immediately */
+			if (kbds_searchobj.directsearch)
+				break;
+			return 0;
 		case XK_BackSpace:
 			if (kbds_searchobj.cx == 0)
 				break;
@@ -1062,14 +1067,6 @@ kbds_keyboardhandler(KeySym ksym, char *buf, int len, int forcequit)
 			selextend(kbds_c.x, kbds_c.y, kbds_seltype, 0);
 		}
 		break;
-	case XK_s:
-		kbds_searchobj.directsearch = (ksym == -2 || ksym == -3);
-		kbds_searchobj.dir = (ksym == XK_question || ksym == -3) ? -1 : 1;
-		kbds_searchobj.cx = kbds_searchobj.len = 0;
-		kbds_searchobj.maxlen = term.col - 2;
-		kbds_setmode(kbds_mode | KBDS_MODE_FLASH);
-		kbds_clearhighlights();
-		return 0;
 	case XK_o:
 	case XK_O:
 		ox = sel.ob.x; oy = sel.ob.y;
@@ -1108,8 +1105,9 @@ kbds_keyboardhandler(KeySym ksym, char *buf, int len, int forcequit)
 		kbds_clearhighlights();
 		return 0;
 	case -4:
-		kbds_searchobj.directsearch = (ksym == -2 || ksym == -3);
-		kbds_searchobj.dir = (ksym == XK_question || ksym == -3) ? -1 : 1;
+	case XK_s:
+		kbds_searchobj.directsearch = (ksym == -4);
+		kbds_searchobj.dir = 1;
 		kbds_searchobj.cx = kbds_searchobj.len = 0;
 		kbds_searchobj.maxlen = term.col - 2;
 		kbds_setmode(kbds_mode | KBDS_MODE_FLASH);

--- a/patch/keyboardselect_st.h
+++ b/patch/keyboardselect_st.h
@@ -2,6 +2,7 @@ void kbds_drawstatusbar(int);
 void kbds_pasteintosearch(const char *, int, int);
 int kbds_isselectmode(void);
 int kbds_issearchmode(void);
+int kbds_isflashmode(void);
 int kbds_drawcursor(void);
 int kbds_getcursor(int *, int *);
 int kbds_keyboardhandler(KeySym, char *, int, int);

--- a/patch/keyboardselect_x.c
+++ b/patch/keyboardselect_x.c
@@ -14,3 +14,9 @@ void searchbackward(const Arg *dummy)
     win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
     kbds_keyboardhandler(-3, NULL, 0, 0);
 }
+
+void keyboard_flash(const Arg *dummy)
+{
+    win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
+    kbds_keyboardhandler(-4, NULL, 0, 0);
+}

--- a/patch/keyboardselect_x.c
+++ b/patch/keyboardselect_x.c
@@ -1,22 +1,22 @@
 void keyboard_select(const Arg *dummy)
 {
-    win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
+	win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
 }
 
 void searchforward(const Arg *dummy)
 {
-    win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
-    kbds_keyboardhandler(-2, NULL, 0, 0);
+	win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
+	kbds_keyboardhandler(-2, NULL, 0, 0);
 }
 
 void searchbackward(const Arg *dummy)
 {
-    win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
-    kbds_keyboardhandler(-3, NULL, 0, 0);
+	win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
+	kbds_keyboardhandler(-3, NULL, 0, 0);
 }
 
 void keyboard_flash(const Arg *dummy)
 {
-    win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
-    kbds_keyboardhandler(-4, NULL, 0, 0);
+	win.mode ^= kbds_keyboardhandler(-1, NULL, 0, 0);
+	kbds_keyboardhandler(-4, NULL, 0, 0);
 }

--- a/patch/keyboardselect_x.h
+++ b/patch/keyboardselect_x.h
@@ -1,3 +1,4 @@
 void keyboard_select(const Arg *);
 void searchforward(const Arg *);
 void searchbackward(const Arg *);
+void keyboard_flash(const Arg *);

--- a/patch/openurlonclick.c
+++ b/patch/openurlonclick.c
@@ -254,7 +254,7 @@ detecturl(int col, int row, int draw)
 }
 
 void
-drawurl(Color *fg, ushort basemode, int x, int y, int charlen, int yoff, int thickness)
+drawurl(Color *fg, Mode basemode, int x, int y, int charlen, int yoff, int thickness)
 {
 	Line line;
 	int i, j, x1, x2, xu, yu, wu, hlink;

--- a/st.h
+++ b/st.h
@@ -68,6 +68,7 @@ enum glyph_attribute {
 	ATTR_HYPERLINK      = 1 << 14,
 	ATTR_BOLD_FAINT = ATTR_BOLD | ATTR_FAINT,
 	ATTR_SIXEL          = 1 << 15,
+	ATTR_FLASH_LABEL    = 1 << 16,
 };
 
 enum extra_attribute {
@@ -144,7 +145,8 @@ typedef XftGlyphFontSpec GlyphFontSpec;
 #define Glyph Glyph_
 typedef struct {
 	Rune u;           /* character code */
-	ushort mode;      /* attribute flags */
+	Rune ubk;		/* character code for flash label */
+	uint32_t mode;   /* attribute flags */
 	ushort hlink;     /* hyperlink index */
 	uint32_t fg;      /* foreground  */
 	uint32_t bg;      /* background  */

--- a/st.h
+++ b/st.h
@@ -137,6 +137,7 @@ typedef unsigned long ulong;
 typedef unsigned short ushort;
 
 typedef uint_least32_t Rune;
+typedef uint32_t Mode;
 
 typedef XftDraw *Draw;
 typedef XftColor Color;
@@ -146,7 +147,7 @@ typedef XftGlyphFontSpec GlyphFontSpec;
 typedef struct {
 	Rune u;           /* character code */
 	Rune ubk;		/* character code for flash label */
-	uint32_t mode;   /* attribute flags */
+	Mode mode;   /* attribute flags */
 	ushort hlink;     /* hyperlink index */
 	uint32_t fg;      /* foreground  */
 	uint32_t bg;      /* background  */

--- a/x.c
+++ b/x.c
@@ -1883,6 +1883,17 @@ xdrawglyphfontspecs(const XftGlyphFontSpec *specs, Glyph base, int len, int x, i
 		bg = &bellbg;
 	}
 
+	if (base.mode & ATTR_FLASH_LABEL) {
+		fg = &dc.col[(base.mode & ATTR_REVERSE) ? flashlabelbg : flashlabelfg];
+		bg = &dc.col[(base.mode & ATTR_REVERSE) ? flashlabelfg : flashlabelbg];
+	}
+	
+	if (!(base.mode & (ATTR_HIGHLIGHT | ATTR_REVERSE | ATTR_WDUMMY | ATTR_FLASH_LABEL)) && kbds_isflashmode()) {
+		fg = &dc.col[flashtextfg];
+		if (base.bg != defaultbg)
+			bg = &dc.col[flashtextbg];
+	}
+
 	if (dmode & DRAW_BG) {
 		/* Intelligent cleaning up of the borders. */
 		if (x == 0) {

--- a/x.c
+++ b/x.c
@@ -69,7 +69,7 @@ char *font2_xresources[FONT2_XRESOURCES_SIZE];
 
 static inline ushort sixd_to_16bit(int);
 #if !DISABLE_LIGATURES
-static inline void xresetfontsettings(ushort mode, Font **font, int *frcflags);
+static inline void xresetfontsettings(Mode mode, Font **font, int *frcflags);
 static int xmakeglyphfontspecs_ligatures(XftGlyphFontSpec *, const Glyph *, int, int, int);
 static inline void xdrawline_ligatures(Line, int, int, int);
 #endif
@@ -1493,7 +1493,7 @@ xinit(int cols, int rows)
 
 #if !DISABLE_LIGATURES
 void
-xresetfontsettings(ushort mode, Font **font, int *frcflags)
+xresetfontsettings(Mode mode, Font **font, int *frcflags)
 {
 	*font = &dc.font;
 	if ((mode & ATTR_ITALIC) && (mode & ATTR_BOLD)) {
@@ -1644,7 +1644,7 @@ int
 xmakeglyphfontspecs_noligatures(XftGlyphFontSpec *specs, const Glyph *glyphs, int len, int x, int y)
 {
 	float winx = borderpx + x * win.cw, winy = borderpx + y * win.ch, xp, yp;
-	ushort mode, prevmode = USHRT_MAX;
+	Mode mode, prevmode = USHRT_MAX;
 	Font *font = &dc.font;
 	int frcflags = FRC_NORMAL;
 	float runewidth = win.cw;

--- a/x.c
+++ b/x.c
@@ -1644,7 +1644,7 @@ int
 xmakeglyphfontspecs_noligatures(XftGlyphFontSpec *specs, const Glyph *glyphs, int len, int x, int y)
 {
 	float winx = borderpx + x * win.cw, winy = borderpx + y * win.ch, xp, yp;
-	Mode mode, prevmode = USHRT_MAX;
+	Mode mode, prevmode = -1;
 	Font *font = &dc.font;
 	int frcflags = FRC_NORMAL;
 	float runewidth = win.cw;

--- a/xresources-example
+++ b/xresources-example
@@ -58,6 +58,12 @@ St.color15:         white
 St.highlightfg:     15
 St.highlightbg:     160
 
+! Foreground and background color of flash label
+St.flashlabelfg: 15
+St.flashlabelbg: 4
+St.flashtextfg:  8
+St.flashtextbg:  0
+
 ! Foreground and background color of the hyperlink hint
 St.hyperlinkhintfg: 0
 St.hyperlinkhintbg: 258


### PR DESCRIPTION
suppor  flash mode in keyborad-select , Just  like [flash.nvim](https://github.com/folke/flash.nvim)


It can quickly position the cursor to any desired position, without gradually moving the cursor by direction or search, which can greatly improve the efficiency of copy and paste

https://github.com/user-attachments/assets/73f17628-bb04-45e7-9700-b0f1f58f0769


