### PR TITLE
Fix build warnings introduced by the newterm patch

### DIFF
--- a/patch/newterm.c
+++ b/patch/newterm.c
@@ -23,9 +23,13 @@ newterm(const Arg* a)
 					setenv("PWD", term.cwd, 1);
 				}
 			} else if (a->i & NEWTERM_FG_CWD) {
-				chdir(get_foreground_cwd());
+				if (chdir(get_foreground_cwd()) != 0) {
+					fprintf(stderr, "newterm failed to change directory to: %s\n", get_foreground_cwd());
+				}
 			} else {
-				chdir(getcwd_by_pid(pid));
+				if (chdir(getcwd_by_pid(pid)) != 0) {
+					fprintf(stderr, "newterm failed to change directory to: %s\n", getcwd_by_pid(pid));
+				}
 			}
 			setsid();
 			execl("/proc/self/exe", argv0, NULL);


### PR DESCRIPTION
This commit fixes the following build warnings that have been introduced by the newterm patch:

```
patch/newterm.c:26:33: warning: ignoring return value of ‘chdir’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   26 |                                 chdir(get_foreground_cwd());
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
patch/newterm.c:28:33: warning: ignoring return value of ‘chdir’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   28 |                                 chdir(getcwd_by_pid(pid));
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~
```