### PR TITLE
Add the ability to disable unfocused bg opacity

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -242,7 +242,11 @@ char *termname = "st-256color";
  */
 unsigned int tabspaces = 8;
 
-/* bg opacity */
+/* bg opacity
+ *
+ * To disable the unfocused bg opacity, set alphaUnfocused=-1. This will
+ * cause alpha to be used for both the focused and unfocused bg opacity.
+ */
 float alpha = 0.93;
 float alphaUnfocused = 0.6;
 

--- a/patch/alpha.c
+++ b/patch/alpha.c
@@ -14,6 +14,8 @@ changealpha(const Arg *arg)
 void
 changealphaunfocused(const Arg *arg)
 {
+	if (alphaUnfocused == -1)
+		return;
 	alphaUnfocused = clamp(arg->f ?  alphaUnfocused + arg->f : alphaUnfocused_def, 0.0, 1.0);
 	xloadcols();
 	redraw();

--- a/x.c
+++ b/x.c
@@ -940,7 +940,7 @@ void
 xloadalpha(void)
 {
 	float usedAlpha = (opt_alpha) ? strtof(opt_alpha, NULL)
-	                              : focused ? alpha : alphaUnfocused;
+	                              : focused || alphaUnfocused == -1 ? alpha : alphaUnfocused;
 
 	dc.col[defaultbg] = focused ? dc.col[bg] : dc.col[bgUnfocused];
 	dc.col[defaultbg].color.alpha = (unsigned short)(0xffff * usedAlpha);


### PR DESCRIPTION
This commit added the ability to disable the unfocused bg opacity by setting alphaUnfocused to -1. Doing so will cause alpha to be used for both the focused and unfocused bg opacity.

One can instead set alpha and alphaUnfocused to be the same value, however these value will deviate as soon as changealpha is used. Setting alphaUnfocused to -1 will ensure the focused and unfocused bg opacity will always be the same; taking into account changealpha.