### PR TITLE
Correct color register count

### DIFF
--- a/sixel.c
+++ b/sixel.c
@@ -610,11 +610,12 @@ sixel_parser_parse(sixel_state_t *st, const unsigned char *p, size_t len)
 				st->param = 0;
 
 				if (st->nparams > 0) {
-					st->color_index = 1 + st->params[0];  /* offset 1(background color) added */
+					st->color_index = st->params[0];
 					if (st->color_index < 0)
 						st->color_index = 0;
 					else if (st->color_index >= DECSIXEL_PALETTE_MAX)
 						st->color_index = DECSIXEL_PALETTE_MAX - 1;
+					st->color_index++; /* offset by 1 (background) */
 				}
 
 				if (st->nparams > 4) {

--- a/sixel.h
+++ b/sixel.h
@@ -49,8 +49,8 @@ typedef struct parser_context {
 	int nparams;
 	int params[DECSIXEL_PARAMS_MAX];
 	int use_private_palette;
-	sixel_color_t shared_palette[DECSIXEL_PALETTE_MAX];
-	sixel_color_t private_palette[DECSIXEL_PALETTE_MAX];
+	sixel_color_t shared_palette[DECSIXEL_PALETTE_MAX + 1];
+	sixel_color_t private_palette[DECSIXEL_PALETTE_MAX + 1];
 	sixel_image_t image;
 } sixel_state_t;
 


### PR DESCRIPTION
st-sx advertises 1024 color registers in XTSMGRAPHICS, but in fact only 1023 were available because 0 is used as a pseudo-register for background (or the lack of it).  This is a problem if a program wishes to actually use all 1024 registers, so I've added an extra slot for the pseudo-register.

For example, following ought to print a red bar, but was printing a green one:

printf '\033P;0q#1022;2;99;0;0#1023;2;0;99;0;0#1022!100~-\033\\\n'